### PR TITLE
changes to ios header name to support static linking changes

### DIFF
--- a/schemas/extension-package-mobile.json
+++ b/schemas/extension-package-mobile.json
@@ -211,7 +211,7 @@
     },
     "iosHeaderName": {
       "type": "string",
-      "pattern": "^[a-zA-Z_][a-zA-Z\\d_]*\\/[a-zA-Z_][a-zA-Z\\d_]*\\.[a-zA-Z]$"
+      "pattern": "^[a-zA-Z_][a-zA-Z\\d_]*\\/?[a-zA-Z_][a-zA-Z\\d_]*\\.[a-zA-Z]$"
     },
     "iosInterface": {
       "type": "string",


### PR DESCRIPTION
## Description

With static linking changes, frameworks are no longer required. Changing the regex pattern to make it optional

## Motivation and Context

We need to change how extensions define ios imports with static linking changes

## How Has This Been Tested?

Tested both old and new patterns of headers. Both:
`ADBMobileMarketing/AdobeAnalytics.h`
and
`AdobeAnalytics.h`
are now valid

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Do these changes need to be released within a particular timeframe?

ASAP. No later than next week

## Do these changes need to be coordinated with changes in other repositories?

<!--- Would there be any problem if these changes were released before/after related changes in other repositories? -->

Non-breaking, backward-compatible change

## Checklist:

<!--- Go over all the following points and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
